### PR TITLE
workaround, BUFFER_LENGTH is not defined in Wire.h for SAMD controllers

### DIFF
--- a/extEEPROM.cpp
+++ b/extEEPROM.cpp
@@ -58,6 +58,12 @@
 #include <extEEPROM.h>
 #include <Wire.h>
 
+// workaround, BUFFER_LENGTH is not defined in Wire.h for SAMD controllers
+#ifndef BUFFER_LENGTH
+#define BUFFER_LENGTH 32
+#endif
+
+
 // Constructor.
 // - deviceCapacity is the capacity of a single EEPROM device in
 //   kilobits (kb) and should be one of the values defined in the


### PR DESCRIPTION
Hi folks

I tried using the extEEPROM lib for a Genuino Zero compatible board which uses a SAMD controller. Unfortunately the Wire.h for SAMD does not define BUFFER_LENGTH which is used in extEEPROM.cpp.

So I suggest this workaround.