### PR TITLE
Fix update() for nBytes equals 1

### DIFF
--- a/extEEPROM.cpp
+++ b/extEEPROM.cpp
@@ -219,6 +219,10 @@ int extEEPROM::read(unsigned long addr)
 //For I2C errors, the status from the Arduino Wire library is passed back through to the caller.
 byte extEEPROM::update(unsigned long addr, byte *values, unsigned int nBytes)
 {
+    if (nBytes == 1) {
+        return update(addr, values[0]);
+    }
+
     return false;
 }
 


### PR DESCRIPTION
Fixes the following compilation errors and implements
update() method for nBytes equals 1:

extEEPROM/extEEPROM.cpp: In member function 'byte extEEPROM::update(long unsigned int, byte*, unsigned int)':
extEEPROM/extEEPROM.cpp:220:38: error: unused parameter 'addr' [-Werror=unused-parameter]
 byte extEEPROM::update(unsigned long addr, byte *values, unsigned int nBytes)
                        ~~~~~~~~~~~~~~^~~~
extEEPROM/extEEPROM.cpp:220:50: error: unused parameter 'values' [-Werror=unused-parameter]
 byte extEEPROM::update(unsigned long addr, byte *values, unsigned int nBytes)
                                            ~~~~~~^~~~~~
extEEPROM/extEEPROM.cpp:220:71: error: unused parameter 'nBytes' [-Werror=unused-parameter]
 byte extEEPROM::update(unsigned long addr, byte *values, unsigned int nBytes)
                                                          ~~~~~~~~~~~~~^~~~~~
cc1plus: all warnings being treated as errors

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>